### PR TITLE
FEATURE added simple actuator line VTK writer to actuatorLineSource 

### DIFF
--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -117,13 +117,32 @@ void Foam::fv::actuatorLineSource::createOutputFile()
 
     if (not isDir(dir))
     {
-        mkDir(dir);
+        Foam::mkDir(dir);
     }
 
     outputFile_ = new OFstream(dir/name_ + ".csv");
 
     *outputFile_<< "time,x,y,z,rel_vel_mag,alpha_deg,alpha_geom_deg,cl,cd,cm"
                 << endl;
+}
+
+void Foam::fv::actuatorLineSource::createOutputDir()
+{
+    if (Pstream::parRun())
+    {
+        vtkDir_ = mesh_.time().path()/"../postProcessing/actuatorLines"
+            / mesh_.time().timeName()/"VTK";
+    }
+    else
+    {
+        vtkDir_ = mesh_.time().path()/"postProcessing/actuatorLines"
+            / mesh_.time().timeName()/"VTK";
+    }
+
+    if (not isDir(vtkDir_))
+    {
+        Foam::mkDir(vtkDir_);
+    }
 }
 
 
@@ -508,6 +527,9 @@ Foam::fv::actuatorLineSource::actuatorLineSource
         )
     ),
     writePerf_(coeffs_.lookupOrDefault("writePerf", false)),
+    writeVTK_(coeffs_.lookupOrDefault("writeVTK", false)),
+	vtkFileSequence_(0),
+    vtkFilePtr_(NULL),
     lastMotionTime_(mesh.time().value()),
     endEffectsActive_(false)
 {
@@ -516,6 +538,10 @@ Foam::fv::actuatorLineSource::actuatorLineSource
     if (writePerf_)
     {
         createOutputFile();
+    }
+    if (writeVTK_)
+    {
+        createOutputDir();
     }
     if (forceField_.writeOpt() == IOobject::AUTO_WRITE)
     {
@@ -692,6 +718,17 @@ void Foam::fv::actuatorLineSource::addSup
     {
         writePerf();
     }
+
+	// write the VTK file
+	if
+	(
+		writeVTK_ && 
+		mesh_.time().outputTime() && 
+		Pstream::master()
+	) 
+	{
+		writeVTK();
+	}
 }
 
 
@@ -761,6 +798,113 @@ void Foam::fv::actuatorLineSource::addSup
     {
         writePerf();
     }
+
+	// write the VTK file
+	if(mesh_.time().outputTime() && Pstream::master()) 
+	{
+		writeVTK();
+	}
+
+}
+
+void Foam::fv::actuatorLineSource::writeVTK()
+{
+
+    fileName vtkFileName;
+
+	// pad the integer name for the VTK reader
+    std::ostringstream cfc;
+    cfc 	<< std::setw(12) 
+		<< std::setfill('0') 
+		<< vtkFileSequence_;
+
+	// construct file name
+	vtkFileName = vtkDir_+"/"+name_+"_"+cfc.str()+".vtk";
+
+	// reset the file pointer to the soon to be written vtk
+    vtkFilePtr_.reset
+    (
+        new OFstream(vtkFileName)
+    );
+
+	// write header and time
+    vtkFilePtr_()
+        << "# vtk DataFile Version 3.0" << nl
+        << "actuator line "<<name_<< nl
+        << "ASCII" << nl
+        << "DATASET POLYDATA" << nl;
+
+	// write Points
+	vtkFilePtr_()
+		<< "POINTS "<<elements_.size()<<" double"<< nl;
+
+		forAll(elements_, i)
+		{
+			vector ePosition (elements_[i].position());
+			vtkFilePtr_() 
+				<< ePosition[0]
+				<< " "
+				<< ePosition[1]
+				<< " "
+				<< ePosition[2]
+				<< nl;
+		}
+
+
+		// write lines connecting nodes
+	vtkFilePtr_()<< "LINES 1 "<<elements_.size()+1<< nl;
+	vtkFilePtr_()<<elements_.size()<<" ";
+
+	for(int i = 0; i<elements_.size();i++)
+	{
+		vtkFilePtr_()<<i<<" ";
+	}
+	vtkFilePtr_() << nl;
+	vtkFilePtr_() << endl;
+
+	// tell VTK there is element data next
+	vtkFilePtr_()
+		<< nl
+		<< "POINT_DATA "<<elements_.size()<<nl;
+
+	// write element velocity
+	vtkFilePtr_()
+		<< "VECTORS Velocity double "<<nl;
+
+		forAll(elements_, i)
+		{
+			vector eVel (elements_[i].velocity());
+			vtkFilePtr_() 
+				<< eVel[0]
+				<< " "
+				<< eVel[1]
+				<< " "
+				<< eVel[2]
+				<< nl;
+		}
+
+	vtkFilePtr_() << endl;
+
+	// write element force
+	vtkFilePtr_()
+		<< "VECTORS Force double "<<nl;
+
+		forAll(elements_, i)
+		{
+			vector eForce (elements_[i].force());
+			vtkFilePtr_() 
+				<< eForce[0]
+				<< " "
+				<< eForce[1]
+				<< " "
+				<< eForce[2]
+				<< nl;
+		}
+
+	vtkFilePtr_() << endl;
+
+	// add to the sequence
+	vtkFileSequence_++;
 }
 
 // ************************************************************************* //

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -528,7 +528,7 @@ Foam::fv::actuatorLineSource::actuatorLineSource
     ),
     writePerf_(coeffs_.lookupOrDefault("writePerf", false)),
     writeVTK_(coeffs_.lookupOrDefault("writeVTK", false)),
-	vtkFileSequence_(0),
+    vtkFileSequence_(0),
     vtkFilePtr_(NULL),
     lastMotionTime_(mesh.time().value()),
     endEffectsActive_(false)
@@ -719,16 +719,16 @@ void Foam::fv::actuatorLineSource::addSup
         writePerf();
     }
 
-	// write the VTK file
-	if
-	(
-		writeVTK_ && 
-		mesh_.time().outputTime() && 
-		Pstream::master()
-	) 
-	{
-		writeVTK();
-	}
+    // write the VTK file
+    if
+    (
+        writeVTK_ &&
+        mesh_.time().outputTime() &&
+        Pstream::master()
+    )
+    {
+        writeVTK();
+    }
 }
 
 
@@ -799,11 +799,11 @@ void Foam::fv::actuatorLineSource::addSup
         writePerf();
     }
 
-	// write the VTK file
-	if(mesh_.time().outputTime() && Pstream::master()) 
-	{
-		writeVTK();
-	}
+    // write the VTK file
+    if (mesh_.time().outputTime() && Pstream::master())
+    {
+        writeVTK();
+    }
 
 }
 
@@ -812,99 +812,99 @@ void Foam::fv::actuatorLineSource::writeVTK()
 
     fileName vtkFileName;
 
-	// pad the integer name for the VTK reader
+    // pad the integer name for the VTK reader
     std::ostringstream cfc;
-    cfc 	<< std::setw(12) 
-		<< std::setfill('0') 
-		<< vtkFileSequence_;
+    cfc     << std::setw(12)
+        << std::setfill('0')
+        << vtkFileSequence_;
 
-	// construct file name
-	vtkFileName = vtkDir_+"/"+name_+"_"+cfc.str()+".vtk";
+    // construct file name
+    vtkFileName = vtkDir_+"/"+name_+"_"+cfc.str()+".vtk";
 
-	// reset the file pointer to the soon to be written vtk
+    // reset the file pointer to the soon to be written vtk
     vtkFilePtr_.reset
     (
         new OFstream(vtkFileName)
     );
 
-	// write header and time
+    // write header and time
     vtkFilePtr_()
         << "# vtk DataFile Version 3.0" << nl
         << "actuator line "<<name_<< nl
         << "ASCII" << nl
         << "DATASET POLYDATA" << nl;
 
-	// write Points
-	vtkFilePtr_()
-		<< "POINTS "<<elements_.size()<<" double"<< nl;
+    // write Points
+    vtkFilePtr_()
+        << "POINTS "<<elements_.size()<<" double"<< nl;
 
-		forAll(elements_, i)
-		{
-			vector ePosition (elements_[i].position());
-			vtkFilePtr_() 
-				<< ePosition[0]
-				<< " "
-				<< ePosition[1]
-				<< " "
-				<< ePosition[2]
-				<< nl;
-		}
+        forAll(elements_, i)
+        {
+            vector ePosition (elements_[i].position());
+            vtkFilePtr_()
+                << ePosition[0]
+                << " "
+                << ePosition[1]
+                << " "
+                << ePosition[2]
+                << nl;
+        }
 
 
-		// write lines connecting nodes
-	vtkFilePtr_()<< "LINES 1 "<<elements_.size()+1<< nl;
-	vtkFilePtr_()<<elements_.size()<<" ";
+        // write lines connecting nodes
+    vtkFilePtr_()<< "LINES 1 "<<elements_.size()+1<< nl;
+    vtkFilePtr_()<<elements_.size()<<" ";
 
-	for(int i = 0; i<elements_.size();i++)
-	{
-		vtkFilePtr_()<<i<<" ";
-	}
-	vtkFilePtr_() << nl;
-	vtkFilePtr_() << endl;
+    for (int i = 0; i<elements_.size();i++)
+    {
+        vtkFilePtr_()<<i<<" ";
+    }
+    vtkFilePtr_() << nl;
+    vtkFilePtr_() << endl;
 
-	// tell VTK there is element data next
-	vtkFilePtr_()
-		<< nl
-		<< "POINT_DATA "<<elements_.size()<<nl;
+    // tell VTK there is element data next
+    vtkFilePtr_()
+        << nl
+        << "POINT_DATA "<<elements_.size()<<nl;
 
-	// write element velocity
-	vtkFilePtr_()
-		<< "VECTORS Velocity double "<<nl;
+    // write element velocity
+    vtkFilePtr_()
+        << "VECTORS Velocity double "<<nl;
 
-		forAll(elements_, i)
-		{
-			vector eVel (elements_[i].velocity());
-			vtkFilePtr_() 
-				<< eVel[0]
-				<< " "
-				<< eVel[1]
-				<< " "
-				<< eVel[2]
-				<< nl;
-		}
+        forAll(elements_, i)
+        {
+            vector eVel (elements_[i].velocity());
+            vtkFilePtr_()
+                << eVel[0]
+                << " "
+                << eVel[1]
+                << " "
+                << eVel[2]
+                << nl;
+        }
 
-	vtkFilePtr_() << endl;
+    vtkFilePtr_() << endl;
 
-	// write element force
-	vtkFilePtr_()
-		<< "VECTORS Force double "<<nl;
+    // write element force
+    vtkFilePtr_()
+        << "VECTORS Force double "<<nl;
 
-		forAll(elements_, i)
-		{
-			vector eForce (elements_[i].force());
-			vtkFilePtr_() 
-				<< eForce[0]
-				<< " "
-				<< eForce[1]
-				<< " "
-				<< eForce[2]
-				<< nl;
-		}
+        forAll(elements_, i)
+        {
+            vector eForce (elements_[i].force());
+            vtkFilePtr_()
+                << eForce[0]
+                << " "
+                << eForce[1]
+                << " "
+                << eForce[2]
+                << nl;
+        }
 
-	vtkFilePtr_() << endl;
+    vtkFilePtr_() << endl;
 
-	// add to the sequence
-	vtkFileSequence_++;
+    // add to the sequence
+    vtkFileSequence_++;
 }
 
 // ************************************************************************* //

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -812,29 +812,29 @@ void Foam::fv::actuatorLineSource::writeVTK()
 
     fileName vtkFileName;
 
-    // pad the integer name for the VTK reader
+    // Pad the integer name for the VTK reader
     std::ostringstream cfc;
     cfc     << std::setw(12)
         << std::setfill('0')
         << vtkFileSequence_;
 
-    // construct file name
+    // Construct file name
     vtkFileName = vtkDir_+"/"+name_+"_"+cfc.str()+".vtk";
 
-    // reset the file pointer to the soon to be written vtk
+    // Reset the file pointer to the soon to be written vtk
     vtkFilePtr_.reset
     (
         new OFstream(vtkFileName)
     );
 
-    // write header and time
+    // Write header and time
     vtkFilePtr_()
         << "# vtk DataFile Version 3.0" << nl
         << "actuator line "<<name_<< nl
         << "ASCII" << nl
         << "DATASET POLYDATA" << nl;
 
-    // write Points
+    // Write Points
     vtkFilePtr_()
         << "POINTS "<<elements_.size()<<" double"<< nl;
 
@@ -851,7 +851,7 @@ void Foam::fv::actuatorLineSource::writeVTK()
         }
 
 
-        // write lines connecting nodes
+    // Write lines connecting nodes
     vtkFilePtr_()<< "LINES 1 "<<elements_.size()+1<< nl;
     vtkFilePtr_()<<elements_.size()<<" ";
 
@@ -862,12 +862,12 @@ void Foam::fv::actuatorLineSource::writeVTK()
     vtkFilePtr_() << nl;
     vtkFilePtr_() << endl;
 
-    // tell VTK there is element data next
+    // Tell VTK there is element data next
     vtkFilePtr_()
         << nl
         << "POINT_DATA "<<elements_.size()<<nl;
 
-    // write element velocity
+    // Write element velocity
     vtkFilePtr_()
         << "VECTORS Velocity double "<<nl;
 
@@ -885,7 +885,7 @@ void Foam::fv::actuatorLineSource::writeVTK()
 
     vtkFilePtr_() << endl;
 
-    // write element force
+    // Write element force
     vtkFilePtr_()
         << "VECTORS Force double "<<nl;
 
@@ -903,7 +903,7 @@ void Foam::fv::actuatorLineSource::writeVTK()
 
     vtkFilePtr_() << endl;
 
-    // add to the sequence
+    // Add to the VTK sequence counter
     vtkFileSequence_++;
 }
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.H
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.H
@@ -41,6 +41,7 @@ SourceFiles
 #include "actuatorLineElement.H"
 #include "cellSetOption.H"
 #include "volFieldsFwd.H"
+#include <iomanip>
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -96,6 +97,18 @@ protected:
         //- Switch for writing performance
         bool writePerf_;
 
+        //- Switch for writing VTK
+        bool writeVTK_;
+
+		//- VTK output directory name
+		fileName vtkDir_;
+
+		//- VTK file counter
+		label vtkFileSequence_;
+
+        //- vtk file ptr
+        mutable autoPtr<OFstream> vtkFilePtr_;
+
         //- Output file stream
         OFstream* outputFile_;
 
@@ -132,6 +145,9 @@ protected:
         //- Create the performance output file
         virtual void createOutputFile();
 
+        //- Create the VTK output directory
+        void createOutputDir();
+
         //- Write performance to CSV
         void writePerf();
 
@@ -140,6 +156,9 @@ protected:
 
         //- Execute harmonic pitching for a single time step
         void harmonicPitching();
+
+		//- actuator line VTk writer
+		void writeVTK();
 
 
 public:

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.H
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.H
@@ -100,11 +100,11 @@ protected:
         //- Switch for writing VTK
         bool writeVTK_;
 
-		//- VTK output directory name
-		fileName vtkDir_;
+        //- VTK output directory name
+        fileName vtkDir_;
 
-		//- VTK file counter
-		label vtkFileSequence_;
+        //- VTK file counter
+        label vtkFileSequence_;
 
         //- vtk file ptr
         mutable autoPtr<OFstream> vtkFilePtr_;
@@ -157,8 +157,8 @@ protected:
         //- Execute harmonic pitching for a single time step
         void harmonicPitching();
 
-		//- actuator line VTk writer
-		void writeVTK();
+        //- actuator line VTk writer
+        void writeVTK();
 
 
 public:

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.H
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.H
@@ -106,7 +106,7 @@ protected:
         //- VTK file counter
         label vtkFileSequence_;
 
-        //- vtk file ptr
+        //- VTK file ptr
         mutable autoPtr<OFstream> vtkFilePtr_;
 
         //- Output file stream
@@ -157,7 +157,7 @@ protected:
         //- Execute harmonic pitching for a single time step
         void harmonicPitching();
 
-        //- actuator line VTk writer
+        //- Actuator line VTK writer
         void writeVTK();
 
 

--- a/tutorials/actuatorLine/pitching/system/fvOptions
+++ b/tutorials/actuatorLine/pitching/system/fvOptions
@@ -28,7 +28,7 @@ foil
         freeStreamVelocity  (29.9 0 0); // M = 0.381
         nElements           4;
         writePerf           true;
-		writeVTK			true;
+        writeVTK            true;
 
         elementGeometry // Will be interpolated linearly per nElements
         ( // point spanDir chordLength chordRefDir chordMount pitch

--- a/tutorials/actuatorLine/pitching/system/fvOptions
+++ b/tutorials/actuatorLine/pitching/system/fvOptions
@@ -28,6 +28,7 @@ foil
         freeStreamVelocity  (29.9 0 0); // M = 0.381
         nElements           4;
         writePerf           true;
+		writeVTK			true;
 
         elementGeometry // Will be interpolated linearly per nElements
         ( // point spanDir chordLength chordRefDir chordMount pitch

--- a/tutorials/actuatorLine/static/system/fvOptions.template
+++ b/tutorials/actuatorLine/static/system/fvOptions.template
@@ -28,6 +28,7 @@ foil
         freeStreamVelocity  (1 0 0);
         nElements           {n_elements};
         writePerf           true;
+		writeVTK			true;
         writeElementPerf    true;
         endEffects          off;
 

--- a/tutorials/actuatorLine/static/system/fvOptions.template
+++ b/tutorials/actuatorLine/static/system/fvOptions.template
@@ -28,7 +28,7 @@ foil
         freeStreamVelocity  (1 0 0);
         nElements           {n_elements};
         writePerf           true;
-		writeVTK			true;
+        writeVTK            true;
         writeElementPerf    true;
         endEffects          off;
 

--- a/tutorials/axialFlowTurbineAL/system/fvOptions
+++ b/tutorials/axialFlowTurbineAL/system/fvOptions
@@ -62,6 +62,7 @@ turbine
             blade1
             {
                 writePerf   true;
+                writeVTK   true;
                 writeElementPerf true;
                 nElements   28;
                 elementProfiles
@@ -118,6 +119,7 @@ turbine
             {
                 $blade1;
                 writePerf   false;
+                writeVTK   true;
                 writeElementPerf false;
                 azimuthalOffset 120.0;
             }

--- a/tutorials/crossFlowTurbineAL/system/fvOptions
+++ b/tutorials/crossFlowTurbineAL/system/fvOptions
@@ -72,6 +72,7 @@ turbine
             blade1
             {
                 writePerf   true;
+				writeVTK	true;
                 writeElementPerf true;
                 nElements   14;
                 endEffects  on;
@@ -86,6 +87,7 @@ turbine
             {
                 $blade1;
                 writePerf   false;
+				writeVTK	true;
                 writeElementPerf false;
                 azimuthalOffset 120.0; // Degrees
             }
@@ -101,6 +103,7 @@ turbine
             strut1
             {
                 writePerf   true;
+				writeVTK	true;
                 nElements   6;
                 elementProfiles (NACA0021);
                 elementData
@@ -113,6 +116,7 @@ turbine
             {
                 $strut1;
                 writePerf   false;
+				writeVTK	true;
                 azimuthalOffset 120.0;
             }
             strut3

--- a/tutorials/crossFlowTurbineAL/system/fvOptions
+++ b/tutorials/crossFlowTurbineAL/system/fvOptions
@@ -72,7 +72,7 @@ turbine
             blade1
             {
                 writePerf   true;
-				writeVTK	true;
+                writeVTK    true;
                 writeElementPerf true;
                 nElements   14;
                 endEffects  on;
@@ -87,7 +87,7 @@ turbine
             {
                 $blade1;
                 writePerf   false;
-				writeVTK	true;
+                writeVTK    true;
                 writeElementPerf false;
                 azimuthalOffset 120.0; // Degrees
             }
@@ -103,7 +103,7 @@ turbine
             strut1
             {
                 writePerf   true;
-				writeVTK	true;
+                writeVTK    true;
                 nElements   6;
                 elementProfiles (NACA0021);
                 elementData
@@ -116,7 +116,7 @@ turbine
             {
                 $strut1;
                 writePerf   false;
-				writeVTK	true;
+                writeVTK    true;
                 azimuthalOffset 120.0;
             }
             strut3
@@ -152,11 +152,11 @@ turbine
                     #include "../../resources/foilData/NACA0021_multiRe_Re"
                 );
                 clData // For tableType = multiRe
-		        (
+                (
                     #include "../../resources/foilData/NACA0021_multiRe_cl"
                 );
                 cdData // For tableType = multiRe
-		        (
+                (
                     #include "../../resources/foilData/NACA0021_multiRe_cd"
                 );
             }


### PR DESCRIPTION
added a simple VTK writer to the actuator line class.  This will output .vtk files to the postProcessing/actuatorLine/<time>/VTK folder that can then be read into ParaView.  Because vtk does not have time annotation, in order to sync the vtk output and the simulation output, you will need to run foamToVTK on the simulation data.  An actuator line VTK output is written for each fluid write time.