### PR TITLE
Fix sign in Goude flow curvature correction

### DIFF
--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -281,7 +281,7 @@ void Foam::fv::actuatorLineElement::correctFlowCurvature
 
     if (flowCurvatureModelName_ == "Goude")
     {
-        angleOfAttackRad += omega_*(chordMount_ - 0.25)
+        angleOfAttackRad += omega_*(chordMount_ + 0.25)
                           * chordLength_/mag(relativeVelocity_);
         angleOfAttackRad += omega_*chordLength_/(4*mag(relativeVelocity_));
     }

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/profileData/profileData.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/profileData/profileData.C
@@ -170,6 +170,21 @@ void Foam::profileData::readMultiRe()
     // Read list of Reynolds numbers for dataset
     dict_.lookup("ReList") >> ReList_;
 
+    // Scale Reynolds numbers if desired
+    // This functionality can be used to approximate full scale loading without
+    // changing the flow Reynolds number
+    // Lookup table will effectively use Reynolds numbers ReScale times
+    // larger than the computed element Reynolds number
+    if (dict_.found("ReScale"))
+    {
+        scalar ReScale = 1.0;
+        dict_.lookup("ReScale") >> ReScale;
+        forAll(ReList_, i)
+        {
+            ReList_[i] = ReList_[i] / ReScale;
+        }
+    }
+
     // Define keywords for coefficient data
     word clKeyword = "clData";
     word cdKeyword = "cdData";


### PR DESCRIPTION
Also added a Reynolds number scaling option to force `profileData` to look for coefficients at different Re.


## TODO

- [ ] Add `ReScale` to CFT tutorial case