### PR TITLE
Fixed bug that could generate NaN in SD dynamic stall model

### DIFF
--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSD/LeishmanBeddoesSD.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSD/LeishmanBeddoesSD.C
@@ -156,6 +156,11 @@ void Foam::fv::LeishmanBeddoesSD::calcSeparated()
         Vx_ = 0.0;
     }
 
+    if (fDoublePrime_ < 0.0)
+    {
+        fDoublePrime_ = 0;
+    }
+
     // Calculate normal force coefficient including dynamic separation point
     CNF_ = CNAlpha_*alphaEquiv_*pow(((1.0 + sqrt(fDoublePrime_))/2.0), 2)
          + CNI_;
@@ -174,6 +179,11 @@ void Foam::fv::LeishmanBeddoesSD::calcSeparated()
     else
     {
         f = 0.02 + 0.58*exp((alpha1_ - mag(alpha_))/S2_);
+    }
+
+    if (f < 0.0)
+    {
+        f = 0.0;
     }
 
     CTStatic_ = eta_*CNAlpha_*alphaEquiv_*alphaEquiv_*(sqrt(f)


### PR DESCRIPTION
Some profile coefficients could cause the code to predict a separation point before the leading edge, which caused the code to crash. Have now limited the separation point to not allow negative values.