### PR TITLE
Add compatibility for OpenFOAM v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ dist: trusty
 language: cpp
 
 env:
-    - OF_VERS=30
-    - OF_VERS=4
     - OF_VERS=5
     - OF_VERS=6
+    - OF_VERS=7
 
 before_install:
     - sudo add-apt-repository http://dl.openfoam.org/ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI setup for turbinesFoam
 
 sudo: required
-dist: trusty
+dist: xenial
 language: cpp
 
 env:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@ turbinesFoam
 ============
 
 [![Build Status](https://travis-ci.org/turbinesFoam/turbinesFoam.svg?branch=master)](https://travis-ci.org/turbinesFoam/turbinesFoam)
+![OpenFOAM 7](https://img.shields.io/badge/OpenFOAM-6-brightgreen.svg)
 ![OpenFOAM 6](https://img.shields.io/badge/OpenFOAM-6-brightgreen.svg)
 ![OpenFOAM 5.x](https://img.shields.io/badge/OpenFOAM-5.x-brightgreen.svg)
-![OpenFOAM 4.x](https://img.shields.io/badge/OpenFOAM-4.x-brightgreen.svg)
-![OpenFOAM 3.0.x](https://img.shields.io/badge/OpenFOAM-3.0.x-brightgreen.svg)
 [![Issues in progress](https://img.shields.io/waffle/label/turbinesFoam/turbinesFoam/in%20progress.svg?maxAge=2592000)](https://waffle.io/turbinesfoam/turbinesfoam)
 [![DOI](https://zenodo.org/badge/4234/turbinesFoam/turbinesFoam.svg)](https://zenodo.org/badge/latestdoi/4234/turbinesFoam/turbinesFoam)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ turbinesFoam
 ![OpenFOAM 7](https://img.shields.io/badge/OpenFOAM-6-brightgreen.svg)
 ![OpenFOAM 6](https://img.shields.io/badge/OpenFOAM-6-brightgreen.svg)
 ![OpenFOAM 5.x](https://img.shields.io/badge/OpenFOAM-5.x-brightgreen.svg)
-[![Issues in progress](https://img.shields.io/waffle/label/turbinesFoam/turbinesFoam/in%20progress.svg?maxAge=2592000)](https://waffle.io/turbinesfoam/turbinesfoam)
 [![DOI](https://zenodo.org/badge/4234/turbinesFoam/turbinesFoam.svg)](https://zenodo.org/badge/latestdoi/4234/turbinesFoam/turbinesFoam)
 
 turbinesFoam is a library for simulating wind and marine hydrokinetic turbines

--- a/README.md
+++ b/README.md
@@ -13,17 +13,16 @@ in OpenFOAM using the actuator line method.
 
 [![](https://cloud.githubusercontent.com/assets/4604869/10141523/f2e3ad9a-65da-11e5-971c-b736abd30c3b.png)](https://www.youtube.com/watch?v=THZvV4R1vow)
 
+Be sure to check out the
+[development snapshot videos on YouTube](https://www.youtube.com/playlist?list=PLOlLyh5gytG8n8D3V1lDeZ3e9fJf9ux-e).
 
-Status
-------
 
-This library is in development and is not yet fully functional.
+Contributing
+------------
+
+Pull requests are very welcome!
 See the [issue tracker](https://github.com/petebachant/turbinesFoam/issues)
 for more details.
-Pull requests are encouraged!
-
-Also be sure to check out the
-[development snapshot videos on YouTube](https://www.youtube.com/playlist?list=PLOlLyh5gytG8n8D3V1lDeZ3e9fJf9ux-e).
 
 
 Features

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -1021,7 +1021,7 @@ void Foam::fv::actuatorLineElement::addSup
         dimensionedVector
         (
             "zero",
-            eqn.dimensions()/dimVolume,
+            forceField.dimensions(),
             vector::zero
         )
     );

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -28,6 +28,7 @@ License
 #include "geometricOneField.H"
 #include "fvMatrices.H"
 #include "syncTools.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -64,7 +64,8 @@ void Foam::fv::actuatorLineElement::read()
     if (dict_.found("dynamicStall"))
     {
         dictionary dsDict = dict_.subDict("dynamicStall");
-        word dsName = dsDict.lookup("dynamicStallModel");
+        word dsName;
+        dsDict.lookup("dynamicStallModel") >> dsName;
         dynamicStall_ = dynamicStallModel::New
         (
             dsDict,

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoes/LeishmanBeddoes.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoes/LeishmanBeddoes.C
@@ -27,6 +27,7 @@ License
 #include "addToRunTimeSelectionTable.H"
 #include "simpleMatrix.H"
 #include "interpolateUtils.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoes3G/LeishmanBeddoes3G.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoes3G/LeishmanBeddoes3G.C
@@ -25,6 +25,7 @@ License
 
 #include "LeishmanBeddoes3G.H"
 #include "addToRunTimeSelectionTable.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSD/LeishmanBeddoesSD.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSD/LeishmanBeddoesSD.C
@@ -25,6 +25,7 @@ License
 
 #include "LeishmanBeddoesSD.H"
 #include "addToRunTimeSelectionTable.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSGC/LeishmanBeddoesSGC.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/dynamicStallModels/LeishmanBeddoesSGC/LeishmanBeddoesSGC.C
@@ -25,6 +25,7 @@ License
 
 #include "LeishmanBeddoesSGC.H"
 #include "addToRunTimeSelectionTable.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/profileData/profileData.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/profileData/profileData.C
@@ -26,6 +26,7 @@ License
 #include "profileData.H"
 #include "interpolateUtils.H"
 #include "simpleMatrix.H"
+#include "unitConversion.H"
 
 // * * * * * * * * * * * * Protected Member Functions  * * * * * * * * * * * //
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -685,7 +685,7 @@ void Foam::fv::actuatorLineSource::addSup
     }
 
     // Zero out force field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
 
     // Zero the total force vector
     force_ = vector::zero;
@@ -755,7 +755,7 @@ void Foam::fv::actuatorLineSource::addSup
     }
 
     // Zero out force field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
 
     // Zero the total force vector
     force_ = vector::zero;

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -518,7 +518,7 @@ Foam::fv::actuatorLineSource::actuatorLineSource
         dimensionedVector
         (
             "force",
-            dimForce/dimVolume/dimDensity,
+            dimForce/dimVolume,
             vector::zero
         )
     ),
@@ -699,6 +699,12 @@ void Foam::fv::actuatorLineSource::addSup
     Info<< "Force (per unit density) on " << name_ << ": "
         << endl << force_ << endl << endl;
 
+    // Check dimensions on force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
+
     // Add source to eqn
     eqn += forceField_;
 
@@ -748,12 +754,6 @@ void Foam::fv::actuatorLineSource::addSup
         harmonicPitching();
     }
 
-    // Check dimensions on force field and correct if necessary
-    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
-    {
-        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
-    }
-
     // Zero out force field
     forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
 
@@ -767,6 +767,12 @@ void Foam::fv::actuatorLineSource::addSup
     }
 
     Info<< "Force on " << name_ << ": " << endl << force_ << endl << endl;
+
+    // Check dimensions on force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
 
     // Add source to eqn
     eqn += forceField_;

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -768,7 +768,7 @@ void Foam::fv::actuatorLineSource::addSup
 
     Info<< "Force on " << name_ << ": " << endl << force_ << endl << endl;
 
-    // Check dimensions on force field and correct if necessary
+    // Check dimensions of force field and correct if necessary
     if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
     {
         forceField_.dimensions().reset(eqn.dimensions()/dimVolume);

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -668,6 +668,12 @@ void Foam::fv::axialFlowTurbineALSource::addSup
     forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
+    // Check dimensions of force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
+
     // Create local moment vector
     vector moment(vector::zero);
 
@@ -755,6 +761,12 @@ void Foam::fv::axialFlowTurbineALSource::addSup
     // Zero out force vector and field
     forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
+
+    // Check dimensions of force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
 
     // Create local moment vector
     vector moment(vector::zero);

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -28,6 +28,7 @@ License
 #include "fvMatrices.H"
 #include "geometricOneField.H"
 #include "syncTools.H"
+#include "unitConversion.H"
 
 using namespace Foam::constant;
 

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -638,7 +638,7 @@ void Foam::fv::axialFlowTurbineALSource::addSup
     }
 
     // Zero out force vector and field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
     // Create local moment vector
@@ -726,7 +726,7 @@ void Foam::fv::axialFlowTurbineALSource::addSup
     }
 
     // Zero out force vector and field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
     // Create local moment vector

--- a/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
+++ b/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
@@ -573,7 +573,7 @@ void Foam::fv::crossFlowTurbineALSource::addSup
     }
 
     // Zero out force vector and field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
     // Create local moment vector
@@ -651,7 +651,7 @@ void Foam::fv::crossFlowTurbineALSource::addSup
     }
 
     // Zero out force vector and field
-    forceField_ *= 0;
+    forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
     // Create local moment vector

--- a/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
+++ b/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
@@ -576,6 +576,12 @@ void Foam::fv::crossFlowTurbineALSource::addSup
     forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
+    // Check dimensions of force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
+
     // Create local moment vector
     vector moment(vector::zero);
 
@@ -584,6 +590,7 @@ void Foam::fv::crossFlowTurbineALSource::addSup
     {
         blades_[i].addSup(eqn, fieldI);
         forceField_ += blades_[i].forceField();
+        Info<< "Added blade" << endl;
         force_ += blades_[i].force();
         bladeMoments_[i] = blades_[i].moment(origin_);
         moment += bladeMoments_[i];
@@ -644,7 +651,7 @@ void Foam::fv::crossFlowTurbineALSource::addSup
         rotate();
     }
 
-    // Check dimensions on force field and correct if necessary
+    // Check dimensions of force field and correct if necessary
     if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
     {
         forceField_.dimensions().reset(eqn.dimensions()/dimVolume);

--- a/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
+++ b/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
@@ -28,6 +28,7 @@ License
 #include "fvMatrices.H"
 #include "geometricOneField.H"
 #include "syncTools.H"
+#include "unitConversion.H"
 
 using namespace Foam::constant;
 

--- a/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
+++ b/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
@@ -651,18 +651,18 @@ void Foam::fv::crossFlowTurbineALSource::addSup
         rotate();
     }
 
-    // Check dimensions of force field and correct if necessary
-    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
-    {
-        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
-    }
-
     // Zero out force vector and field
     forceField_ *= dimensionedScalar("zero", forceField_.dimensions(), 0.0);
     force_ *= 0;
 
     // Create local moment vector
     vector moment(vector::zero);
+
+    // Check dimensions of force field and correct if necessary
+    if (forceField_.dimensions() != eqn.dimensions()/dimVolume)
+    {
+        forceField_.dimensions().reset(eqn.dimensions()/dimVolume);
+    }
 
     // Add source for blade actuator lines
     forAll(blades_, i)

--- a/src/fvOptions/turbineALSource/turbineALSource.C
+++ b/src/fvOptions/turbineALSource/turbineALSource.C
@@ -28,6 +28,7 @@ License
 #include "fvMatrices.H"
 #include "geometricOneField.H"
 #include "syncTools.H"
+#include "unitConversion.H"
 
 using namespace Foam::constant;
 


### PR DESCRIPTION
Resolves #290.

Currently there are some issues with dimensions being incompatible inside the turbine `addSup` methods where the blade force fields are added to the turbine force fields. I've tried resetting the dimensions and still get the same error, so I'm a bit stumped for now.

```
--> FOAM FATAL ERROR:
Different dimensions for '(a += b)'
     dimensions : [0 2 -4 0 0 0 0] != [0 1 -2 0 0 0 0]
```