### PR TITLE
Added compatibility with multiphase solvers

### DIFF
--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.C
@@ -59,6 +59,8 @@ void Foam::fv::actuatorLineElement::read()
     dict_.lookup("rootDistance") >> rootDistance_;
     dict_.lookup("velocitySampleRadius") >> velocitySampleRadius_;
     dict_.lookup("nVelocitySamples") >> nVelocitySamples_;
+    dict_.lookup("multiPhase") >> multiPhase_;
+    dict_.lookup("phaseName") >> phaseName_;
 
     // Create dynamic stall model if found
     if (dict_.found("dynamicStall"))
@@ -94,8 +96,20 @@ void Foam::fv::actuatorLineElement::read()
     (
         "transportProperties"
     );
+
     dimensionedScalar nu;
-    transportProperties.lookup("nu") >> nu;
+
+    // If problem is multi-phase, then we look for phase (air, water, ...) subdictionary in transportProperties
+    if (multiPhase_)
+    {
+        dictionary transportPropertiesPhase = transportProperties.subDict(phaseName_);
+        transportPropertiesPhase.lookup("nu") >> nu;
+    }
+    else
+    {
+        transportProperties.lookup("nu") >> nu;
+    }
+
     nu_ = nu.value();
 
     // Read writePerf switch

--- a/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.H
+++ b/src/fvOptions/actuatorLineSource/actuatorLineElement/actuatorLineElement.H
@@ -201,6 +201,11 @@ protected:
         //- Number of elements used to sample velocities
         label nVelocitySamples_;
 
+        //- Switch for multiphase simulations
+        bool multiPhase_;
+
+        //- Name of the main phase which properties are to be read
+        word phaseName_;
 
     // Protected Member Functions
 

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.C
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.C
@@ -68,6 +68,13 @@ bool Foam::fv::actuatorLineSource::read(const dictionary& dict)
         freeStreamDirection_ = freeStreamVelocity_/mag(freeStreamVelocity_);
         endEffectsActive_ = coeffs_.lookupOrDefault("endEffects", false);
 
+        // Multi-phase parameters, if present
+        multiPhase_ = coeffs_.lookupOrDefault("multiPhase", false);
+        if(multiPhase_)
+        {
+            coeffs_.lookup("phaseName") >> phaseName_;
+        }
+
         // Read harmonic pitching parameters if present
         dictionary pitchDict = coeffs_.subOrEmptyDict("harmonicPitching");
         harmonicPitchingActive_ = pitchDict.lookupOrDefault("active", false);
@@ -333,6 +340,8 @@ void Foam::fv::actuatorLineSource::createElements()
             coeffs_.lookupOrDefault("writeElementPerf", false)
         );
         dict.add("writePerf", writeElementPerf);
+        dict.add("multiPhase", multiPhase_);
+        dict.add("phaseName", phaseName_);
 
         if (debug)
         {

--- a/src/fvOptions/actuatorLineSource/actuatorLineSource.H
+++ b/src/fvOptions/actuatorLineSource/actuatorLineSource.H
@@ -120,6 +120,11 @@ protected:
         //- Switch for correcting end effects
         bool endEffectsActive_;
 
+        //- Switch for multiphase simulations
+        bool multiPhase_;
+
+        //- Name of the phase which properties are to be used
+        word phaseName_;
 
     // Protected Member Functions
 

--- a/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
+++ b/src/fvOptions/axialFlowTurbineALSource/axialFlowTurbineALSource.C
@@ -244,6 +244,13 @@ void Foam::fv::axialFlowTurbineALSource::createBlades()
         // Do not write force from individual actuator line unless specified
         bladeSubDict.lookupOrAddDefault("writeForceField", false);
 
+        // Add multiphase data
+        bladeSubDict.add("multiPhase", multiPhase_);
+        if(multiPhase_)
+        {
+            bladeSubDict.add("phaseName", coeffs_.lookup("phaseName"));
+        }
+
         dictionary dict;
         dict.add("actuatorLineSourceCoeffs", bladeSubDict);
         dict.add("type", "actuatorLineSource");
@@ -339,6 +346,13 @@ void Foam::fv::axialFlowTurbineALSource::createHub()
     // Do not write force from individual actuator line unless specified
     hubSubDict.lookupOrAddDefault("writeForceField", false);
 
+    // Add multiphase data
+    hubSubDict.add("multiPhase", multiPhase_);
+    if(multiPhase_)
+    {
+        hubSubDict.add("phaseName", coeffs_.lookup("phaseName"));
+    }
+
     dictionary dict;
     dict.add("actuatorLineSourceCoeffs", hubSubDict);
     dict.add("type", "actuatorLineSource");
@@ -427,6 +441,13 @@ void Foam::fv::axialFlowTurbineALSource::createTower()
     // Do not write force from individual actuator line unless specified
     towerSubDict.lookupOrAddDefault("writeForceField", false);
 
+    // Add multiphase data
+    towerSubDict.add("multiPhase", multiPhase_);
+    if(multiPhase_)
+    {
+        towerSubDict.add("phaseName", coeffs_.lookup("phaseName"));
+    }
+    
     dictionary dict;
     dict.add("actuatorLineSourceCoeffs", towerSubDict);
     dict.add("type", "actuatorLineSource");

--- a/src/fvOptions/turbineALSource/turbineALSource.C
+++ b/src/fvOptions/turbineALSource/turbineALSource.C
@@ -316,6 +316,8 @@ bool Foam::fv::turbineALSource::read(const dictionary& dict)
         tsrAmplitude_ = coeffs_.lookupOrDefault("tsrAmplitude", 0.0);
         tsrPhase_ = coeffs_.lookupOrDefault("tsrPhase", 0.0);
 
+        // Read multiphase switch
+        multiPhase_ = coeffs_.lookupOrDefault("multiPhase", false);
         // Get blade information
         bladesDict_ = coeffs_.subDict("blades");
         nBlades_ = bladesDict_.keys().size();

--- a/src/fvOptions/turbineALSource/turbineALSource.H
+++ b/src/fvOptions/turbineALSource/turbineALSource.H
@@ -152,6 +152,8 @@ protected:
         //- Individual blade moments about turbine origin
         List<vector> bladeMoments_;
 
+        //- Switch for multiphase simulations
+        bool multiPhase_;
 
     // Protected Member Functions
 


### PR DESCRIPTION
For multiphase simulations, the user must specify two new coefficients: '_multiPhase_' (bool, true means multi-phase solver is used) and '_phaseName_' (word, only needed if multiPhase is true, should correspond to the main phase name - usually air- as defined in the 'transportProperties' dictionary). This is done to pick the correct value for kinematic viscosity.

This commit is meant to serve as the initial commit for a 'floatingTurbine' branch. As part of my MSc thesis, some modifications are made to the original library to make it compatible with the 6-DoF motion characterizing floating wind turbines (FWTs). The final goal is that the AL turbine can be used in multiphase simulations, where _[waves2Foam](https://openfoamwiki.net/index.php/Contrib/waves2Foam)_ will be used for wave generation and absorption. Both libraries need to be coupled together and, at the same time, to the rigid body solver for the floating turbine motion. The tool resulting from the project should have the potential to be validated and expanded to serve as a reliable technique for the advanced modelling of FWTs.