### PR TITLE
Functionality for VAWT blades with cone angles (allows modelling the Troposkien shape and other unconventional lift-based VAWTs)

### DIFF
--- a/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
+++ b/src/fvOptions/crossFlowTurbineALSource/crossFlowTurbineALSource.C
@@ -167,10 +167,11 @@ void Foam::fv::crossFlowTurbineALSource::createBlades()
             elementGeometry[j][0][2] = point.z(); // z location of geom point
 
             // Set span directions for AL source
-            vector spanDir = origin_; // Initialising the span-direction vector
-            spanDir += 0*freeStreamDirection_;
-            spanDir += sin(degToRad(cone))*radialDirection_;
-            spanDir += cos(degToRad(cone))*axis_;
+            // Initialize span direction and take into account cone angle
+            vector spanDir = (
+                cos(degToRad(cone))*axis_
+                + sin(degToRad(cone))*radialDirection_
+            );
             rotateVector(spanDir, vector::zero, axis_, azimuthRadians);
             elementGeometry[j][1][0] = spanDir.x(); // x component of span dir
             elementGeometry[j][1][1] = spanDir.y(); // y component of span dir


### PR DESCRIPTION
The current version of turbinesFoam does not allow the flexibility to include non-straight bladed VAWTs. As troposkien VAWTs are quite common (Sandia 34m), it becomes necessary to model their wake.

The implementation that I have done here adds an additional input parameter called 'coneAngle', which allows users to specify the cone-angle of a blade section with respect to the vertical-axis. This addition is then reflected while calculating the 'spanDirection', where the cone angles are added to make sure that the spanDirection is modified in accordance with the 'coneAngle'. 

This should open up more uses of turbinesFoam for VAWT wake analysis for other VAWT shapes. 